### PR TITLE
feat: show celebration when day completed

### DIFF
--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { type TaskBlock as TaskBlockType, type Category } from '~/types';
 import TaskBlock from './TaskBlock';
 import dayjs from 'dayjs';
+import CelebrationOverlay from './CelebrationOverlay';
 
 interface CalendarDayProps {
   date: Date;
@@ -27,6 +28,7 @@ function CalendarDay({
   isWeekView = false,
 }: CalendarDayProps) {
   const [isDragOver, setIsDragOver] = useState(false);
+  const [showCelebration, setShowCelebration] = useState(false);
 
   const dateString = dayjs(date).format('YYYY-MM-DD');
   const dayTaskBlocks = taskBlocks.filter((block) => block.date === dateString);
@@ -74,6 +76,14 @@ function CalendarDay({
   const totalCount = dayTaskBlocks.length;
   const completionPercentage =
     totalCount > 0 ? (completedCount / totalCount) * 100 : 0;
+
+  useEffect(() => {
+    if (completionPercentage === 100 && totalCount > 0) {
+      setShowCelebration(true);
+      const timer = setTimeout(() => setShowCelebration(false), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [completionPercentage, totalCount]);
 
   const dayClasses = `
     ${isWeekView ? 'min-h-[200px]' : 'min-h-[120px]'} p-2 border border-gray-200 bg-white relative
@@ -169,6 +179,7 @@ function CalendarDay({
           <div className="w-2 h-2 bg-blue-600 rounded-full"></div>
         </div>
       )}
+      {showCelebration && <CelebrationOverlay />}
     </div>
   );
 }

--- a/src/components/CelebrationOverlay.tsx
+++ b/src/components/CelebrationOverlay.tsx
@@ -6,7 +6,8 @@ function CelebrationOverlay() {
   const pieces = useMemo(
     () =>
       Array.from({ length: 80 }).map(() => ({
-        left: Math.random() * 100,
+        top: Math.random() * 100,
+        fromLeft: Math.random() < 0.5,
         delay: Math.random() * 0.5,
         color: COLORS[Math.floor(Math.random() * COLORS.length)],
       })),
@@ -21,9 +22,9 @@ function CelebrationOverlay() {
       {pieces.map((p, i) => (
         <span
           key={i}
-          className="confetti-piece"
+          className={`confetti-piece ${p.fromLeft ? 'from-left' : 'from-right'}`}
           style={{
-            left: `${p.left}%`,
+            top: `${p.top}%`,
             backgroundColor: p.color,
             animationDelay: `${p.delay}s`,
           }}

--- a/src/components/CelebrationOverlay.tsx
+++ b/src/components/CelebrationOverlay.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+
+const COLORS = ['#FDE68A', '#FCA5A5', '#BFDBFE', '#A7F3D0', '#FDBA74'];
+
+function CelebrationOverlay() {
+  const pieces = useMemo(
+    () =>
+      Array.from({ length: 80 }).map(() => ({
+        left: Math.random() * 100,
+        delay: Math.random() * 0.5,
+        color: COLORS[Math.floor(Math.random() * COLORS.length)],
+      })),
+    []
+  );
+
+  return (
+    <div
+      data-testid="celebration-overlay"
+      className="pointer-events-none fixed inset-0 overflow-hidden z-50"
+    >
+      {pieces.map((p, i) => (
+        <span
+          key={i}
+          className="confetti-piece"
+          style={{
+            left: `${p.left}%`,
+            backgroundColor: p.color,
+            animationDelay: `${p.delay}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default CelebrationOverlay;

--- a/src/components/__tests__/CalendarDay.test.tsx
+++ b/src/components/__tests__/CalendarDay.test.tsx
@@ -135,6 +135,21 @@ describe('CalendarDay', () => {
       expect(completionIcon).toBeInTheDocument();
     });
 
+    it('すべてのタスク完了時に祝いアニメーションが表示されること', async () => {
+      const allCompletedTaskBlocks = mockTaskBlocks.map((task) => ({
+        ...task,
+        completed: true,
+      }));
+
+      render(
+        <CalendarDay {...defaultProps} taskBlocks={allCompletedTaskBlocks} />
+      );
+
+      expect(
+        await screen.findByTestId('celebration-overlay')
+      ).toBeInTheDocument();
+    });
+
     it('一部のタスクが完了している場合にチェックマークが表示されないこと', () => {
       render(<CalendarDay {...defaultProps} />);
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -9,22 +9,41 @@ body {
   padding: 0;
 }
 
-@keyframes confetti-fall {
+@keyframes confetti-left {
   0% {
-    transform: translateY(0) rotate(0deg);
+    transform: translateX(0) rotate(0deg);
     opacity: 1;
   }
   100% {
-    transform: translateY(100vh) rotate(360deg);
+    transform: translateX(100vw) rotate(360deg);
+    opacity: 0;
+  }
+}
+
+@keyframes confetti-right {
+  0% {
+    transform: translateX(0) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-100vw) rotate(-360deg);
     opacity: 0;
   }
 }
 
 .confetti-piece {
   position: absolute;
-  top: -10px;
   width: 6px;
   height: 12px;
   opacity: 0.9;
-  animation: confetti-fall 3s ease-out forwards;
+}
+
+.confetti-piece.from-left {
+  left: -10px;
+  animation: confetti-left 1.5s ease-out forwards;
+}
+
+.confetti-piece.from-right {
+  right: -10px;
+  animation: confetti-right 1.5s ease-out forwards;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -8,3 +8,23 @@ body {
   margin: 0;
   padding: 0;
 }
+
+@keyframes confetti-fall {
+  0% {
+    transform: translateY(0) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(100vh) rotate(360deg);
+    opacity: 0;
+  }
+}
+
+.confetti-piece {
+  position: absolute;
+  top: -10px;
+  width: 6px;
+  height: 12px;
+  opacity: 0.9;
+  animation: confetti-fall 3s ease-out forwards;
+}


### PR DESCRIPTION
## Summary
- add reusable CelebrationOverlay component
- trigger overlay when all tasks in a day are completed
- document confetti styles and test the animation

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6c2e90048832dac9ff0e767dbfb68