### PR TITLE
Fix unit calculation to schedule final task block

### DIFF
--- a/src/lib/queries/category.ts
+++ b/src/lib/queries/category.ts
@@ -93,8 +93,9 @@ export function getCategoryProgress(
   const taskBlocks = storage
     .getTaskBlocks()
     .filter((t) => t.categoryId === category.id);
-  const completedBlocks = taskBlocks.filter((t) => t.completed);
+  const completedUnits = taskBlocks
+    .filter((t) => t.completed)
+    .reduce((sum, t) => sum + t.amount, 0);
   const total = getTotalUnits(category);
-  const completed = completedBlocks.length;
-  return calculateProgress(completed, total);
+  return calculateProgress(completedUnits, total);
 }

--- a/src/lib/utils/__tests__/range.test.ts
+++ b/src/lib/utils/__tests__/range.test.ts
@@ -162,7 +162,7 @@ describe('range utilities', () => {
       expect(availableRanges).toEqual([
         { start: 0, end: 20 },
         { start: 30, end: 50 },
-        { start: 60, end: 100 },
+        { start: 60, end: 105 },
       ]);
     });
 
@@ -170,13 +170,13 @@ describe('range utilities', () => {
       const availableRanges = getAvailableRanges(mockCategory, []);
 
       expect(availableRanges).toEqual([
-        { start: 0, end: 100 },
+        { start: 0, end: 105 },
       ]);
     });
 
     it('完了済み範囲が全範囲を覆う場合は空配列を返すこと', () => {
       const completedRanges: Range[] = [
-        { start: 0, end: 100 },
+        { start: 0, end: 105 },
       ];
 
       const availableRanges = getAvailableRanges(mockCategory, completedRanges);
@@ -196,7 +196,7 @@ describe('range utilities', () => {
       expect(availableRanges).toEqual([
         { start: 0, end: 10 },
         { start: 25, end: 40 },
-        { start: 50, end: 100 },
+        { start: 50, end: 105 },
       ]);
     });
   });

--- a/src/lib/utils/category.ts
+++ b/src/lib/utils/category.ts
@@ -1,8 +1,10 @@
 import { type Category } from '~/types';
 
-// total units should represent the actual measurable range, not the number of blocks
+// total units represent the measurable range including the final unit
 export function getTotalUnits(category: Category): number {
-  return category.valueRange.max - category.valueRange.min;
+  return (
+    category.valueRange.max - category.valueRange.min + category.minUnit
+  );
 }
 
 export function calculateProgress(

--- a/src/lib/utils/category.ts
+++ b/src/lib/utils/category.ts
@@ -1,16 +1,15 @@
 import { type Category } from '~/types';
 
+// total units should represent the actual measurable range, not the number of blocks
 export function getTotalUnits(category: Category): number {
-  return Math.ceil(
-    (category.valueRange.max - category.valueRange.min + 1) / category.minUnit
-  );
+  return category.valueRange.max - category.valueRange.min;
 }
 
 export function calculateProgress(
-  completedBlocksCount: number,
+  completedUnits: number,
   totalUnits: number
 ) {
   const percentage =
-    totalUnits > 0 ? Math.round((completedBlocksCount / totalUnits) * 100) : 0;
-  return { completed: completedBlocksCount, total: totalUnits, percentage };
+    totalUnits > 0 ? Math.round((completedUnits / totalUnits) * 100) : 0;
+  return { completed: completedUnits, total: totalUnits, percentage };
 }

--- a/src/lib/utils/range.ts
+++ b/src/lib/utils/range.ts
@@ -64,7 +64,7 @@ export function getAvailableRanges(
   const availableRanges: Range[] = [];
 
   let currentStart = category.valueRange.min;
-  const maxEnd = category.valueRange.max;
+  const maxEnd = category.valueRange.max + category.minUnit;
 
   for (const completedRange of mergedCompletedRanges) {
     // 完了済み範囲の前に利用可能な範囲があるかチェック


### PR DESCRIPTION
## Summary
- correct total unit calculation to avoid missing final block
- adjust category progress to sum completed units

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7785a1c00832dae0a506a42843ac7