### PR TITLE
Add today overview section for tasks

### DIFF
--- a/src/__tests__/integration/basicFlow.integration.test.tsx
+++ b/src/__tests__/integration/basicFlow.integration.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '~/test/utils';
 import App from '~/app/App';
+import { type Project } from '~/types';
 
 // localStorage をモック
 const localStorageMock = {
@@ -80,7 +81,7 @@ describe('基本フローインテグレーション', () => {
 
     it('プロジェクト作成が正常に動作し、詳細画面への遷移ができること', async () => {
       // localStorageのセットアップを改善
-      let savedProjects: any[] = [];
+      let savedProjects: Project[] = [];
       localStorageMock.setItem.mockImplementation((key: string, value: string) => {
         if (key === 'goal-steps-projects') {
           savedProjects = JSON.parse(value);

--- a/src/components/TodayTasksSection.tsx
+++ b/src/components/TodayTasksSection.tsx
@@ -1,0 +1,165 @@
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
+import { type TaskBlock as TaskBlockType, type Category } from '~/types';
+import TaskBlock from './TaskBlock';
+
+interface TodayTasksSectionProps {
+  taskBlocks: TaskBlockType[];
+  categories: Category[];
+  onToggleTaskCompletion: (
+    blockId: string,
+    completed: boolean
+  ) => void | Promise<void>;
+}
+
+function TodayTasksSection({
+  taskBlocks,
+  categories,
+  onToggleTaskCompletion,
+}: TodayTasksSectionProps) {
+  const dayNames = ['日', '月', '火', '水', '木', '金', '土'];
+  const todayKey = dayjs().format('YYYY-MM-DD');
+
+  const { overdueBlocks, todaysBlocks } = useMemo(() => {
+    const today = dayjs(todayKey);
+
+    const sortBlocks = (blocks: TaskBlockType[]) =>
+      [...blocks].sort((a, b) => {
+        const dateDiff = dayjs(a.date).diff(dayjs(b.date));
+        if (dateDiff !== 0) return dateDiff;
+        return a.start - b.start;
+      });
+
+    const overdue = taskBlocks.filter(
+      (block) => !block.completed && dayjs(block.date).isBefore(today, 'day')
+    );
+
+    const todays = taskBlocks.filter((block) =>
+      dayjs(block.date).isSame(today, 'day')
+    );
+
+    return {
+      overdueBlocks: sortBlocks(overdue),
+      todaysBlocks: sortBlocks(todays),
+    };
+  }, [taskBlocks, todayKey]);
+
+  const totalTasksCount = overdueBlocks.length + todaysBlocks.length;
+  const completedCount = todaysBlocks.filter((block) => block.completed).length;
+
+  const getCategory = (categoryId: string) =>
+    categories.find((category) => category.id === categoryId);
+
+  const formatDateLabel = (dateString: string) => {
+    const date = dayjs(dateString);
+    return `${date.format('M/D')} (${dayNames[date.day()]})`;
+  };
+
+  const renderTask = (block: TaskBlockType, { showDate }: { showDate: boolean }) => {
+    const category = getCategory(block.categoryId);
+
+    if (!category) {
+      return null;
+    }
+
+    return (
+      <div key={block.id} className="flex flex-col min-w-[180px]">
+        {showDate && (
+          <div className="text-xs text-gray-500 pl-1 mb-1">
+            予定日: {formatDateLabel(block.date)}
+          </div>
+        )}
+        <TaskBlock
+          block={block}
+          category={category}
+          onToggleCompletion={(blockId, completed) => {
+            void onToggleTaskCompletion(blockId, completed);
+          }}
+          isCompact={true}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md">
+      <div className="flex justify-between items-center border-b border-gray-200 p-4">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">今日のやること</h2>
+          <p className="text-gray-600 mt-1 text-sm">
+            未完了の過去タスクと本日予定のタスクをまとめて確認しましょう
+          </p>
+        </div>
+        {totalTasksCount > 0 && (
+          <div className="text-sm text-gray-600">
+            完了: {completedCount} / {totalTasksCount}
+          </div>
+        )}
+      </div>
+
+      <div className="p-4 space-y-6">
+        {totalTasksCount === 0 ? (
+          <div className="text-sm text-gray-500">
+            本日に対応するタスクはありません。
+          </div>
+        ) : (
+          <>
+            {overdueBlocks.length > 0 && (
+              <div>
+                <div className="flex items-center text-sm font-semibold text-red-600">
+                  <svg
+                    className="w-4 h-4 mr-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  未完了のタスク（〜昨日）
+                </div>
+                <div className="mt-3 flex flex-wrap gap-3">
+                  {overdueBlocks.map((block) =>
+                    renderTask(block, { showDate: true })
+                  )}
+                </div>
+              </div>
+            )}
+
+            {todaysBlocks.length > 0 && (
+              <div>
+                <div className="flex items-center text-sm font-semibold text-blue-600">
+                  <svg
+                    className="w-4 h-4 mr-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M8 7V3m8 4V3m-9 8h10m-12 8h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                    />
+                  </svg>
+                  今日のタスク
+                </div>
+                <div className="mt-3 flex flex-wrap gap-3">
+                  {todaysBlocks.map((block) =>
+                    renderTask(block, { showDate: false })
+                  )}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default TodayTasksSection;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,3 +9,4 @@ export { default as PlanningPanel } from './PlanningPanel';
 export { default as Calendar } from './Calendar';
 export { default as CalendarDay } from './CalendarDay';
 export { default as TaskBlock } from './TaskBlock';
+export { default as TodayTasksSection } from './TodayTasksSection';

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -10,6 +10,7 @@ import CategoryForm from '~/components/CategoryForm';
 import WeeklySettingsForm from '~/components/WeeklySettingsForm';
 import PlanningPanel from '~/components/PlanningPanel';
 import Calendar from '~/components/Calendar';
+import TodayTasksSection from '~/components/TodayTasksSection';
 import Modal from '~/components/Modal';
 
 function ProjectDetailPage() {
@@ -276,6 +277,17 @@ function ProjectDetailPage() {
             }}
           />
         </div>
+      )}
+
+      {/* 今日のやることセクション */}
+      {taskBlocks.length > 0 && (
+        <TodayTasksSection
+          taskBlocks={taskBlocks}
+          categories={categories}
+          onToggleTaskCompletion={async (blockId, completed) => {
+            await toggleTaskCompletion(blockId, completed);
+          }}
+        />
       )}
 
       {/* カレンダー表示セクション */}


### PR DESCRIPTION
## Summary
- add a TodayTasksSection component that surfaces overdue and current-day blocks with completion toggles
- show the new section on the project detail page and expose the component via the shared index
- fix the integration test helper to use the Project type instead of any so linting passes

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d0abc4b9cc832d9c7502425484e5a0